### PR TITLE
refactor: Use basic views and controllers structure 

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,0 @@
-from zeep import Client
-
-client = Client("http://localhost:8080/service?wsdl")

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 import flask
-import pages.home
+from src.views import views
 
-app = flask.Flask(__name__, template_folder="templates")
-
-app.register_blueprint(pages.home.home)
+app = flask.Flask(__name__)
+app.register_blueprint(views)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/pages/home/__init__.py
+++ b/pages/home/__init__.py
@@ -1,6 +1,0 @@
-import flask
-from ._view import view
-
-
-home = flask.Blueprint("home", __name__)
-home.register_blueprint(view)

--- a/src/config/environment.py
+++ b/src/config/environment.py
@@ -1,0 +1,5 @@
+import os
+
+variables = {
+    "GATEWAY_BASEURL": os.getenv("GATEWAY_BASEURL", "http://localhost:8080"),
+}

--- a/src/config/soap_client.py
+++ b/src/config/soap_client.py
@@ -1,0 +1,5 @@
+from zeep import Client
+from .environment import variables
+
+soap_wsdl = f"{variables['GATEWAY_BASEURL']}/service?wsdl"
+soap_client = Client(soap_wsdl)

--- a/src/controllers/_authentication_controllers.py
+++ b/src/controllers/_authentication_controllers.py
@@ -1,18 +1,8 @@
-import flask
 from flask import request
-from config import client
+from src.config.soap_client import soap_client
 
 
-view = flask.Blueprint("home", __name__)
-
-
-@view.route("/", methods=["GET"])
-def index():
-    return flask.render_template("index.html")
-
-
-@view.route("/auth_login", methods=["POST"])
-def auth_login():
+def login_handler():
     try:
         # Get JSON data from the request
         data = request.json
@@ -26,9 +16,9 @@ def auth_login():
         if not username or not password:
             return {"message": "Required fields are missing in JSON data"}, 400
 
-        result = client.service.auth_login({"username": username, "password": password})
-
-        print(result)
+        result = soap_client.service.auth_login(
+            {"username": username, "password": password}
+        )
 
         if result.auth is not None:
             token = result.auth.token

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -1,0 +1,9 @@
+import flask
+from ._authentication_views import views as authentication_views
+
+
+# NOTE: Register all views / routes using the following blueprint
+views = flask.Blueprint("views", __name__)
+
+
+views.register_blueprint(authentication_views)

--- a/src/views/_authentication_views.py
+++ b/src/views/_authentication_views.py
@@ -1,0 +1,9 @@
+import flask
+from src.controllers import _authentication_controllers
+
+views = flask.Blueprint("authentication", __name__)
+
+
+@views.route("/auth_login", methods=["POST"])
+def auth_login():
+    return _authentication_controllers.login_handler()

--- a/src/views/_authentication_views_test.py
+++ b/src/views/_authentication_views_test.py
@@ -1,6 +1,6 @@
 import json
 from main import app
-from config import client
+from config.soap_client import soap_client
 
 
 def test_view() -> None:
@@ -11,7 +11,7 @@ def test_view() -> None:
 def test_auth_login_successful() -> None:
     registration_data = {"username": "miguel3", "password": "miguel3"}
 
-    registration_result = client.service.account_register(registration_data)
+    registration_result = soap_client.service.account_register(registration_data)
 
     assert registration_result.error is False
 

--- a/src/views/_authentication_views_test.py
+++ b/src/views/_authentication_views_test.py
@@ -3,11 +3,6 @@ from main import app
 from config.soap_client import soap_client
 
 
-def test_view() -> None:
-    response = app.test_client().get("/")
-    assert response.status_code == 200
-
-
 def test_auth_login_successful() -> None:
     registration_data = {"username": "miguel3", "password": "miguel3"}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,0 @@
-<h1>Hello world</h1>


### PR DESCRIPTION
Includes: 

- `src` module to keep all the source files coupled. 
- `src/config` module to keep config files and a global SOAP connection. 
- `src/views` module to keep all the endpoints. 
- `src/controllers` module to keep the endpoint controllers. 