### PR TITLE
fix: Enable CORS

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,10 @@
+# CLI
+
+This document describes how to use the service as a CLI tool.
+
+## Environment variables
+
+| Variable          | Description                                            | Example                                    |
+| ----------------- | ------------------------------------------------------ | ------------------------------------------ |
+| `GATEWAY_BASEURL` | Base URL of the gateway                                | `https://gateway:8080`                     |
+| `ALLOWED_ORIGINS` | An string with the allowed origins separated by commas | `https://example.com,https://example2.com` |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ COPY . .
 USER application
 RUN pip install -r requirements.txt
 ENV GATEWAY_BASEURL "http://gateway:8080"
+ENV ALLOWED_ORIGINS "http://localhost:5173"
 ENTRYPOINT ["python", "-m", "flask", "-A", "./main.py", "run", "--host", "0.0.0.0", "--port", "8080"]

--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
 import flask
+from flask_cors import CORS
 from src.views import views
 
 app = flask.Flask(__name__)
 app.register_blueprint(views)
 
+
+CORS(app, resources={r"/auth/*": {"origins": "http://localhost:5173"}})
+
 if __name__ == "__main__":
     app.run(debug=True)
+

--- a/main.py
+++ b/main.py
@@ -1,12 +1,14 @@
 import flask
 from flask_cors import CORS
 from src.views import views
+from src.config.environment import variables
 
 app = flask.Flask(__name__)
 app.register_blueprint(views)
 
+allowed_origins_list = variables["ALLOWED_ORIGINS"].split(",")
 
-CORS(app, resources={r"/auth/*": {"origins": "http://localhost:5173"}})
+CORS(app, resources={r"/*": {"origins": allowed_origins_list}})
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/main.py
+++ b/main.py
@@ -10,4 +10,3 @@ CORS(app, resources={r"/auth/*": {"origins": "http://localhost:5173"}})
 
 if __name__ == "__main__":
     app.run(debug=True)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ urllib3==2.0.4
 Werkzeug==2.3.7
 wrapt==1.15.0
 zeep==4.2.1
+flask-cors==4.0.0

--- a/src/config/environment.py
+++ b/src/config/environment.py
@@ -2,4 +2,5 @@ import os
 
 variables = {
     "GATEWAY_BASEURL": os.getenv("GATEWAY_BASEURL", "http://localhost:8080"),
+    "ALLOWED_ORIGINS": os.getenv("ALLOWED_ORIGINS", "http://localhost:5173"),
 }


### PR DESCRIPTION
- Enable the CORS setting in Flask (Python) to allow cross-origin requests (CORS) from http://localhost:5173 (React) in the context of authentication. This is required for authentication to work correctly in the local development environment.